### PR TITLE
Issue with get_objects_sextractor method from photometry.py

### DIFF
--- a/stdpipe/photometry.py
+++ b/stdpipe/photometry.py
@@ -416,7 +416,7 @@ def get_objects_sextractor(image, header=None, mask=None, err=None, thresh=2.0, 
         obj['x'] -= 1
         obj['y'] -= 1
 
-        if 'x_psf' in obj:
+        if 'x_psf' in obj.keys():
             obj['x_psf'] -= 1
             obj['y_psf'] -= 1
 


### PR DESCRIPTION
Hi @karpov-sv!

I've been working on integrating stdpipe with SkyPortal (https://github.com/skyportal/skyportal) and the `get_objects_sextractor` has been giving me errors consistently. 

This was working just fine about a month and a half ago. I guess that some changes made to newer versions of astropy or even python (those are 2 things I updated since then) could have broken it.

This ver minor change should fix it.

Thanks!