### PR TITLE
np.int, np.bool attributes deprecated for numpy>1.20

### DIFF
--- a/stdpipe/astrometry.py
+++ b/stdpipe/astrometry.py
@@ -671,7 +671,7 @@ def refine_wcs_scamp(obj, cat=None, wcs=None, header=None, sr=2/3600, order=3,
                 'MAG': utils.table_get(cat, cat_col_mag, 0),
                 'MAGERR': utils.table_get(cat, cat_col_mag_err, 0.01),
                 'OBSDATE': np.ones_like(cat[cat_col_ra])*2000.0,
-                'FLAGS': np.zeros_like(cat[cat_col_ra], dtype=np.int),
+                'FLAGS': np.zeros_like(cat[cat_col_ra], dtype=int),
             })
 
             # Remove masked values

--- a/stdpipe/pipeline.py
+++ b/stdpipe/pipeline.py
@@ -321,7 +321,8 @@ def calibrate_photometry(obj, cat, sr=None, pixscale=None, order=0, bg_order=Non
     else:
         cat_magerr = None
 
-    m = photometry.match(obj['ra'], obj['dec'], obj[obj_col_mag], obj[obj_col_mag_err], obj['flags'],
+    m = photometry.match(obj['ra'], obj['dec'], obj[obj_col_mag],
+                         obj[obj_col_mag_err], obj['flags'],
                          cat[cat_col_ra], cat[cat_col_dec], cat[cat_col_mag],
                          cat_magerr=cat_magerr,
                          sr=sr, cat_color=color,

--- a/stdpipe/psf.py
+++ b/stdpipe/psf.py
@@ -352,8 +352,8 @@ def place_psf_stamp(image, psf, x0, y0, flux=1, gain=None):
 
     # Corresponding image pixels
     y1,x1 = np.mgrid[0:stamp.shape[0], 0:stamp.shape[1]]
-    x1 += utils.float2int_array((np.round(x0) - np.floor(stamp.shape[1]/2)))
-    y1 += utils.float2int_array((np.round(y0) - np.floor(stamp.shape[0]/2)))
+    x1 += int(np.round(x0) - np.floor(stamp.shape[1]/2))
+    y1 += int(np.round(y0) - np.floor(stamp.shape[0]/2))
 
     # Crop the coordinates outside target image
     idx = np.isfinite(stamp)

--- a/stdpipe/psf.py
+++ b/stdpipe/psf.py
@@ -198,9 +198,9 @@ def bilinear_interpolate(im, x, y):
     x = np.asarray(x)
     y = np.asarray(y)
 
-    x0 = np.floor(x).astype(np.int)
+    x0 = np.floor(x).astype(int)
     x1 = x0 + 1
-    y0 = np.floor(y).astype(np.int)
+    y0 = np.floor(y).astype(int)
     y1 = y0 + 1
 
     x0 = np.clip(x0, 0, im.shape[1] - 1);
@@ -352,8 +352,8 @@ def place_psf_stamp(image, psf, x0, y0, flux=1, gain=None):
 
     # Corresponding image pixels
     y1,x1 = np.mgrid[0:stamp.shape[0], 0:stamp.shape[1]]
-    x1 += np.int(np.round(x0) - np.floor(stamp.shape[1]/2))
-    y1 += np.int(np.round(y0) - np.floor(stamp.shape[0]/2))
+    x1 += utils.float2int_array((np.round(x0) - np.floor(stamp.shape[1]/2)))
+    y1 += utils.float2int_array((np.round(y0) - np.floor(stamp.shape[0]/2)))
 
     # Crop the coordinates outside target image
     idx = np.isfinite(stamp)

--- a/stdpipe/templates.py
+++ b/stdpipe/templates.py
@@ -231,15 +231,15 @@ def mask_template(tmpl, cat=None, cat_saturation_mag=None,
         tmask = ~np.isfinite(tmpl)
         log(np.sum(tmask), 'template pixels masked after NaN checking')
     else:
-        tmask = np.zeros_like(tmpl, dtype=np.bool)
+        tmask = np.zeros_like(tmpl, dtype=bool)
 
     if cat is not None and wcs is not None:
         # Mask the central pixels of saturated stars
         cx, cy = wcs.all_world2pix(cat[cat_col_ra], cat[cat_col_dec], 0)
-        cx = np.round(cx).astype(np.int)
-        cy = np.round(cy).astype(np.int)
+        cx = np.round(cx).astype(int)
+        cy = np.round(cy).astype(int)
 
-        tidx = np.zeros(len(cat), dtype=np.bool)
+        tidx = np.zeros(len(cat), dtype=bool)
 
         # First, we select all catalogue objects with masked measurements
         if mask_masked:
@@ -619,11 +619,11 @@ def reproject_swarp(input=[], wcs=None, shape=None, width=None, height=None, hea
 
         # it seems SWarp adds BZERO to the output if inputs had them (e.g. unsigned ints do)
         # FIXME: this point needs further investigation!
-        if np.issubdtype(coadd.dtype.type, np.integer):
+        if np.issubdtype(coadd.dtype.type, int):
             coadd -= bzero
 
         if use_nans:
-            if np.issubdtype(coadd.dtype.type, np.floating):
+            if np.issubdtype(coadd.dtype.type, float):
                 coadd[weights == 0] = np.nan
             else:
                 coadd[weights == 0] = 0xffff

--- a/stdpipe/utils.py
+++ b/stdpipe/utils.py
@@ -304,21 +304,3 @@ def file_write(filename, contents=None, append=False):
     with open(filename, 'a' if append else 'w') as f:
         if contents is not None:
             f.write(contents)
-            
-def float2int_array(x):
-    """
-    Simple function to convert array of float into array of int
-
-    Parameters
-    ----------
-    x : np.array
-        Array of float elements.
-
-    Returns
-    -------
-    TYPE
-        Array of int elements.
-
-    """
-    res = np.vectorize(int)(x)
-    return res

--- a/stdpipe/utils.py
+++ b/stdpipe/utils.py
@@ -176,7 +176,7 @@ def table_get(table, colname, default=0):
         return default
     else:
         # Broadcast scalar to proper length
-        return default*np.ones(len(table), dtype=np.int)
+        return default*np.ones(len(table), dtype=int)
 
 def format_astromatic_opts(opts):
     """
@@ -304,3 +304,21 @@ def file_write(filename, contents=None, append=False):
     with open(filename, 'a' if append else 'w') as f:
         if contents is not None:
             f.write(contents)
+            
+def float2int_array(x):
+    """
+    Simple function to convert array of float into array of int
+
+    Parameters
+    ----------
+    x : np.array
+        Array of float elements.
+
+    Returns
+    -------
+    TYPE
+        Array of int elements.
+
+    """
+    res = np.vectorize(int)(x)
+    return res


### PR DESCRIPTION
minor bug correction due to the upgrade of numpy>1.20 that is no longer compatible with int, float, str, bool attributes. Adding a function in utils to convert float arrays into int arrays