### PR TITLE
Fix KeyError in xmatch_skybot when SkyBot returns empty result

### DIFF
--- a/stdpipe/catalogs.py
+++ b/stdpipe/catalogs.py
@@ -697,7 +697,10 @@ def xmatch_skybot(
     except (RuntimeError, KeyError, ConnectionError, OSError):
         # Nothing found in SkyBot
         return None
-
+        
+    if xcat is None or len(xcat) == 0:
+        return None
+        
     # Cross-match objects
     oidx, cidx, dist = astrometry.spherical_match(
         obj[col_ra], obj[col_dec], xcat['RA'], xcat['DEC'], 10 / 3600


### PR DESCRIPTION
I found that `xmatch_skybot()` crashes with `KeyError: 'RA'` when `Skybot.cone_search()` succeeds but returns an empty table.
The existing try-except block handled query failures, but not the case where the query succeeds with zero results.