### PR TITLE
Add inter-process file locking for skycell cache downloads

### DIFF
--- a/stdpipe/templates.py
+++ b/stdpipe/templates.py
@@ -665,46 +665,53 @@ def get_skycells(
         if os.path.exists(filename) and not overwrite:
             log('%s already downloaded' % os.path.split(filename)[-1])
         else:
-            log('Downloading %s' % cellname)
+            # Guard the download with an inter-process lock so that concurrent
+            # workers do not download the same skycell file in parallel
+            with utils.file_lock(filename):
+                if os.path.exists(filename) and not overwrite:
+                    # Another process downloaded it while we waited for the lock
+                    log('%s already downloaded' % os.path.split(filename)[-1])
+                else:
+                    log('Downloading %s' % cellname)
 
-            hdu = fits_open_remote(cell)
-            if hdu is not None:
-                image, header = hdu[1].data, hdu[1].header
+                    hdu = fits_open_remote(cell)
+                    if hdu is not None:
+                        image, header = hdu[1].data, hdu[1].header
 
-                if normalize:
-                    if survey == 'ps1':
-                        image, header = normalize_ps1_skycell(image, header)
+                        if normalize:
+                            if survey == 'ps1':
+                                image, header = normalize_ps1_skycell(image, header)
 
-                    if survey == 'ls' and ext == 'image':
-                        try:
-                            # Get invvar file to mask not covered regions
-                            ihdu = fits_open_remote(cell.replace('-image-', '-invvar-'))
-                            if ihdu is not None:
-                                invvar = ihdu[1].data
-                                image[invvar == 0] = np.nan
-                                ihdu.close()
-                        except Exception:
-                            pass
+                            if survey == 'ls' and ext == 'image':
+                                try:
+                                    # Get invvar file to mask not covered regions
+                                    ihdu = fits_open_remote(cell.replace('-image-', '-invvar-'))
+                                    if ihdu is not None:
+                                        invvar = ihdu[1].data
+                                        image[invvar == 0] = np.nan
+                                        ihdu.close()
+                                except Exception:
+                                    pass
 
-                if _cache_downscale > 1:
-                    image, header = cutouts.downscale_image(
-                        image,
-                        header=header,
-                        scale=_cache_downscale,
-                        mode='or' if ext == 'mask' else 'sum',
-                    )
+                        if _cache_downscale > 1:
+                            image, header = cutouts.downscale_image(
+                                image,
+                                header=header,
+                                scale=_cache_downscale,
+                                mode='or' if ext == 'mask' else 'sum',
+                            )
 
-                    log(
-                        "Downscaling the image and storing it as",
-                        os.path.split(filename)[-1],
-                    )
+                            log(
+                                "Downscaling the image and storing it as",
+                                os.path.split(filename)[-1],
+                            )
 
-                # Write atomically so that an interrupted write does not leave
-                # a truncated file in the cache
-                fits.writeto(filename + '.tmp', image, header, overwrite=True)
-                os.replace(filename + '.tmp', filename)
+                        # Write atomically so that an interrupted write does not leave
+                        # a truncated file in the cache
+                        fits.writeto(filename + '.tmp', image, header, overwrite=True)
+                        os.replace(filename + '.tmp', filename)
 
-                hdu.close()
+                        hdu.close()
 
         if os.path.exists(filename):
             filenames.append(filename)

--- a/stdpipe/utils.py
+++ b/stdpipe/utils.py
@@ -61,12 +61,38 @@ def file_lock(path):
     """
     lockpath = path + '.lock'
     os.makedirs(os.path.dirname(lockpath) or '.', exist_ok=True)
-    with open(lockpath, 'w') as lockfile:
-        fcntl.flock(lockfile, fcntl.LOCK_EX)
+
+    try:
+        # The lock file never needs to be writable: flock() locks the open
+        # file description, not the contents, so an exclusive lock on a
+        # read-only fd is perfectly valid. Opening read-only also lets
+        # other users sharing the cache directory acquire the lock even
+        # when the file belongs to someone else.
+        fd = os.open(lockpath, os.O_CREAT | os.O_RDONLY, 0o666)
+    except OSError:
+        # Lock unavailable (e.g. genuinely read-only cache directory) -
+        # degrade to running unlocked. This is safe as long as the caller
+        # writes atomically (e.g. .tmp file + os.replace); the lock is
+        # only an optimisation against duplicate concurrent downloads.
+        fd = None
+
+    if fd is None:
+        yield
+        return
+
+    try:
+        # Make the lock usable by other users sharing the cache; the mode
+        # above is masked by umask, and fails harmlessly if the file
+        # belongs to someone else
         try:
-            yield
-        finally:
-            fcntl.flock(lockfile, fcntl.LOCK_UN)
+            os.fchmod(fd, 0o666)
+        except OSError:
+            pass
+
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        os.close(fd)  # closing the descriptor releases the lock
 
 
 def download(url, filename=None, overwrite=False, verbose=False):

--- a/stdpipe/utils.py
+++ b/stdpipe/utils.py
@@ -3,6 +3,9 @@ import re
 import requests
 import dateutil
 import shlex
+import fcntl
+
+from contextlib import contextmanager
 
 from tqdm.auto import tqdm
 
@@ -37,6 +40,33 @@ def get_data_path(dataname):
     Returns full path to the data file located in the module data/ folder
     """
     return os.path.join(os.path.dirname(__file__), 'data', dataname)
+
+
+@contextmanager
+def file_lock(path):
+    """Exclusive inter-process lock using a companion ``<path>.lock`` file.
+
+    Based on ``fcntl.flock`` (advisory locking) - all cooperating processes
+    must acquire the lock before touching the file. The lock is automatically
+    released if the process dies, so no stale locks are possible. Lock files
+    are left behind (they are empty and harmless) as removing them would
+    race with other processes opening them.
+
+    The typical pattern for cache downloads is::
+
+        if not os.path.exists(filename):
+            with file_lock(filename):
+                if not os.path.exists(filename):  # re-check inside the lock
+                    ... download and write filename ...
+    """
+    lockpath = path + '.lock'
+    os.makedirs(os.path.dirname(lockpath) or '.', exist_ok=True)
+    with open(lockpath, 'w') as lockfile:
+        fcntl.flock(lockfile, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lockfile, fcntl.LOCK_UN)
 
 
 def download(url, filename=None, overwrite=False, verbose=False):

--- a/stdpipe/utils.py
+++ b/stdpipe/utils.py
@@ -3,7 +3,11 @@ import re
 import requests
 import dateutil
 import shlex
-import fcntl
+
+try:
+    import fcntl
+except ImportError:  # Windows and other non-POSIX platforms
+    fcntl = None
 
 from contextlib import contextmanager
 
@@ -59,6 +63,12 @@ def file_lock(path):
                 if not os.path.exists(filename):  # re-check inside the lock
                     ... download and write filename ...
     """
+    if fcntl is None:
+        # No advisory locking available (non-POSIX platform) - proceed
+        # without deduplication, keeping the pre-locking behaviour
+        yield
+        return
+
     lockpath = path + '.lock'
     os.makedirs(os.path.dirname(lockpath) or '.', exist_ok=True)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -114,6 +114,81 @@ class TestDownload:
         pytest.skip("Network test - implement if needed")
 
 
+class TestFileLock:
+    """Test inter-process file locking."""
+
+    @pytest.mark.unit
+    def test_file_lock_basic(self, temp_dir):
+        """Test that the lock context manager works and leaves the lock file behind."""
+        path = os.path.join(temp_dir, 'file.fits')
+
+        with utils.file_lock(path):
+            assert os.path.exists(path + '.lock')
+
+        # Lock file is left behind (empty and harmless)
+        assert os.path.exists(path + '.lock')
+
+    @pytest.mark.unit
+    def test_file_lock_mutual_exclusion(self, temp_dir):
+        """Test that two processes never hold the lock at the same time."""
+        if utils.fcntl is None:
+            pytest.skip("fcntl not available on this platform")
+
+        import multiprocessing
+        import time
+
+        path = os.path.join(temp_dir, 'file.fits')
+
+        def worker(queue):
+            with utils.file_lock(path):
+                t1 = time.time()
+                time.sleep(0.3)
+                t2 = time.time()
+            queue.put((t1, t2))
+
+        ctx = multiprocessing.get_context('fork')
+        queue = ctx.Queue()
+        procs = [ctx.Process(target=worker, args=(queue,)) for _ in range(2)]
+        for p in procs:
+            p.start()
+        for p in procs:
+            p.join()
+
+        intervals = sorted(queue.get() for _ in range(2))
+        # Second interval starts only after the first one ends
+        assert intervals[1][0] >= intervals[0][1]
+
+    @pytest.mark.unit
+    def test_file_lock_noop_without_fcntl(self, temp_dir, monkeypatch):
+        """Test that file_lock degrades to a no-op when fcntl is unavailable."""
+        monkeypatch.setattr(utils, 'fcntl', None)
+
+        path = os.path.join(temp_dir, 'file.fits')
+
+        with utils.file_lock(path):
+            pass  # should just proceed
+
+        # No lock file is created in no-op mode
+        assert not os.path.exists(path + '.lock')
+
+    @pytest.mark.unit
+    def test_file_lock_degrades_on_readonly_dir(self, temp_dir):
+        """Test that an unwritable directory degrades to running unlocked."""
+        if utils.fcntl is None:
+            pytest.skip("fcntl not available on this platform")
+
+        import stat
+
+        ro_dir = os.path.join(temp_dir, 'readonly')
+        os.makedirs(ro_dir)
+        os.chmod(ro_dir, stat.S_IRUSR | stat.S_IXUSR)  # 0o500
+        try:
+            with utils.file_lock(os.path.join(ro_dir, 'file.fits')):
+                pass  # should degrade to unlocked instead of raising
+        finally:
+            os.chmod(ro_dir, stat.S_IRWXU)
+
+
 class TestFITSUtilities:
     """Test FITS header parsing and utilities."""
 


### PR DESCRIPTION
When several worker processes (e.g. Celery workers) process tasks covering the same sky region concurrently, each of them may start downloading the same skycell/brick file simultaneously — every skycell is tens to hundreds of MB, so this wastes both bandwidth and wall-clock time.

This PR adds `utils.file_lock()`, an advisory lock based on `fcntl.flock` over a companion `<file>.lock` file, and uses it in `get_skycells()` with the double-check pattern: the cache file's existence is verified again after the lock is acquired, so a process that waited for the lock simply uses the file downloaded by the lock holder.

Notes:

- The lock is released automatically even if the process dies (kernel-held), so no stale locks are possible. The empty `.lock` files left behind are harmless.
- `fcntl` is POSIX-only; on Windows this would need a fallback (e.g. the `filelock` package). Happy to add one if you want Windows support.
- Downloads were already atomic (`.tmp` + `os.replace`); this PR only prevents duplicate concurrent downloads.
