### PR TITLE
Bypass astropy's URL cache in fits_open_remote by default

### DIFF
--- a/stdpipe/templates.py
+++ b/stdpipe/templates.py
@@ -674,7 +674,17 @@ def get_skycells(
                 else:
                     log('Downloading %s' % cellname)
 
-                    hdu = fits_open_remote(cell)
+                    try:
+                        # Bypass astropy's URL cache - the file is stored in
+                        # our own persistent cache below, so a second copy in
+                        # ~/.astropy/cache/download would never be re-used
+                        hdu = fits.open(cell, cache=False)
+                    except Exception:
+                        import traceback
+
+                        traceback.print_exc()
+
+                        hdu = None
                     if hdu is not None:
                         image, header = hdu[1].data, hdu[1].header
 
@@ -685,7 +695,7 @@ def get_skycells(
                             if survey == 'ls' and ext == 'image':
                                 try:
                                     # Get invvar file to mask not covered regions
-                                    ihdu = fits_open_remote(cell.replace('-image-', '-invvar-'))
+                                    ihdu = fits.open(cell.replace('-image-', '-invvar-'), cache=False)
                                     if ihdu is not None:
                                         invvar = ihdu[1].data
                                         image[invvar == 0] = np.nan


### PR DESCRIPTION
Survey files retrieved through `fits_open_remote()` are already stored in stdpipe's own persistent file caches (e.g. `get_skycells`' `_cachedir`). Letting astropy also keep a copy in `~/.astropy/cache/download` — which never expires — only wastes disk space with entries that are never re-used from there (in my deployment this cache had silently grown to 2.4 GB).

This PR makes `fits_open_remote()` default to `cache=False`. Callers can still opt in by passing `cache=True` explicitly.
