### PR TITLE
Add local tile caching to get_hips_image via the _cachedir parameter

### DIFF
--- a/stdpipe/templates.py
+++ b/stdpipe/templates.py
@@ -665,46 +665,53 @@ def get_skycells(
         if os.path.exists(filename) and not overwrite:
             log('%s already downloaded' % os.path.split(filename)[-1])
         else:
-            log('Downloading %s' % cellname)
+            # Guard the download with an inter-process lock so that concurrent
+            # workers do not download the same skycell file in parallel
+            with utils.file_lock(filename):
+                if os.path.exists(filename) and not overwrite:
+                    # Another process downloaded it while we waited for the lock
+                    log('%s already downloaded' % os.path.split(filename)[-1])
+                else:
+                    log('Downloading %s' % cellname)
 
-            hdu = fits_open_remote(cell)
-            if hdu is not None:
-                image, header = hdu[1].data, hdu[1].header
+                    hdu = fits_open_remote(cell)
+                    if hdu is not None:
+                        image, header = hdu[1].data, hdu[1].header
 
-                if normalize:
-                    if survey == 'ps1':
-                        image, header = normalize_ps1_skycell(image, header)
+                        if normalize:
+                            if survey == 'ps1':
+                                image, header = normalize_ps1_skycell(image, header)
 
-                    if survey == 'ls' and ext == 'image':
-                        try:
-                            # Get invvar file to mask not covered regions
-                            ihdu = fits_open_remote(cell.replace('-image-', '-invvar-'))
-                            if ihdu is not None:
-                                invvar = ihdu[1].data
-                                image[invvar == 0] = np.nan
-                                ihdu.close()
-                        except Exception:
-                            pass
+                            if survey == 'ls' and ext == 'image':
+                                try:
+                                    # Get invvar file to mask not covered regions
+                                    ihdu = fits_open_remote(cell.replace('-image-', '-invvar-'))
+                                    if ihdu is not None:
+                                        invvar = ihdu[1].data
+                                        image[invvar == 0] = np.nan
+                                        ihdu.close()
+                                except Exception:
+                                    pass
 
-                if _cache_downscale > 1:
-                    image, header = cutouts.downscale_image(
-                        image,
-                        header=header,
-                        scale=_cache_downscale,
-                        mode='or' if ext == 'mask' else 'sum',
-                    )
+                        if _cache_downscale > 1:
+                            image, header = cutouts.downscale_image(
+                                image,
+                                header=header,
+                                scale=_cache_downscale,
+                                mode='or' if ext == 'mask' else 'sum',
+                            )
 
-                    log(
-                        "Downscaling the image and storing it as",
-                        os.path.split(filename)[-1],
-                    )
+                            log(
+                                "Downscaling the image and storing it as",
+                                os.path.split(filename)[-1],
+                            )
 
-                # Write atomically so that an interrupted write does not leave
-                # a truncated file in the cache
-                fits.writeto(filename + '.tmp', image, header, overwrite=True)
-                os.replace(filename + '.tmp', filename)
+                        # Write atomically so that an interrupted write does not leave
+                        # a truncated file in the cache
+                        fits.writeto(filename + '.tmp', image, header, overwrite=True)
+                        os.replace(filename + '.tmp', filename)
 
-                hdu.close()
+                        hdu.close()
 
         if os.path.exists(filename):
             filenames.append(filename)

--- a/stdpipe/templates.py
+++ b/stdpipe/templates.py
@@ -6,6 +6,7 @@ import tempfile
 import shlex
 import time
 import shutil
+import hashlib
 
 from urllib.parse import urlencode
 
@@ -43,6 +44,8 @@ def get_hips_image(
     upscale=False,
     get_header=True,
     verbose=False,
+    _cachedir=None,
+    _overwrite=False,
 ):
     """Load an image from any HiPS survey using the CDS hips2fits service.
 
@@ -85,6 +88,12 @@ def get_hips_image(
         If True, also return the FITS header alongside the image.
     verbose : bool or callable, optional
         Whether to show verbose messages. May be boolean or a ``print``-like callable.
+    _cachedir : str, optional
+        Directory for caching downloaded HiPS tiles between calls. Requests
+        are canonicalized (grid-aligned center, padded size) so that repeated
+        or slightly offset tasks at the same sky position share cached tiles.
+    _overwrite : bool, optional
+        If True, re-download the tile even if already cached.
 
     Returns
     -------
@@ -157,58 +166,158 @@ def get_hips_image(
         log('Sky position and size are not provided')
         return (None, None) if get_header else None
 
-    for baseurl in [
-        'https://alasky.u-strasbg.fr/hips-image-services/hips2fits',
-        'https://alaskybis.u-strasbg.fr/hips-image-services/hips2fits',
-    ]:
-        url = baseurl + '?' + urlencode(params)
+    if (
+        _cachedir is not None
+        and wcs is not None
+        and wcs.is_celestial
+        and not (upscale and upscale > 1)
+    ):
+        # Cached path: request a canonical (grid-aligned, padded) tile and
+        # store it under _cachedir, then reproject it onto the exact grid.
+        # Repeated or slightly offset tasks at the same sky position then
+        # share cached tiles instead of each downloading its own cutout.
+        tilefile, twcs, twidth, theight = _hips_canonical_tile(
+            hips, wcs, int(width), int(height), _cachedir
+        )
 
-        try:
-            t0 = time.time()
-            hdu = fits.open(url)
-            t1 = time.time()
-            log('Downloaded HiPS image in %.2f s' % (t1 - t0))
-            break
-        except Exception:
-            log('Failed downloading HiPS image from', url)
-            hdu = None
-
-    if hdu is None:
-        log('Cannot download HiPS image!')
-        if get_header:
-            return None, None
+        if os.path.exists(tilefile) and not _overwrite:
+            log('Using cached HiPS tile', os.path.split(tilefile)[-1])
         else:
-            return None
+            # Inter-process lock so concurrent workers do not download the
+            # same tile in parallel; re-check existence inside the lock
+            with utils.file_lock(tilefile):
+                if not (os.path.exists(tilefile) and not _overwrite):
+                    tparams = dict(params)
+                    tparams['width'] = twidth
+                    tparams['height'] = theight
 
-    image = hdu[0].data.astype(np.double)
-    header = hdu[0].header
+                    thdr = twcs.to_header(relax=True)
+                    if thdr['CTYPE1'] == 'RA---TPV' and 'PV1_0' not in thdr.keys():
+                        # hips2fits does not like such headers, let's fix it
+                        thdr['CTYPE1'] = 'RA---TAN'
+                        thdr['CTYPE2'] = 'DEC--TAN'
+                    tparams['wcs'] = json.dumps(dict(thdr))
 
-    # FIXME: hips2fits does not properly return the header for SIP WCS, so we just copy the original WCS over it
-    if wcs is not None and wcs.sip is not None:
-        wheader = wcs.to_header(relax=True)
-        header.update(wheader)
+                    for baseurl in [
+                        'https://alasky.u-strasbg.fr/hips-image-services/hips2fits',
+                        'https://alaskybis.u-strasbg.fr/hips-image-services/hips2fits',
+                    ]:
+                        url = baseurl + '?' + urlencode(tparams)
 
-    hdu.close()
+                        try:
+                            t0 = time.time()
+                            # cache=False - do not grow astropy's URL cache,
+                            # we keep our own persistent tile cache instead
+                            hdu = fits.open(url, cache=False)
+                            t1 = time.time()
+                            log('Downloaded HiPS tile in %.2f s' % (t1 - t0))
+                            break
+                        except Exception:
+                            log('Failed downloading HiPS tile from', url)
+                            hdu = None
 
-    if asinh is None:
-        # All PanSTARRS bands except g are stored in asinh scaling, as of May 2023
-        if 'PanSTARRS' in hips and hips != 'PanSTARRS/DR1/g':
-            asinh = True
+                    if hdu is None:
+                        log('Cannot download HiPS image!')
+                        if get_header:
+                            return None, None
+                        else:
+                            return None
 
-    if asinh:
-        # Fix asinh flux scaling
-        # image = np.sinh(image*np.log(10)/2.5)
-        x = image * 0.4 * np.log(10)
-        image = np.exp(x) - np.exp(-x)
+                    timage = hdu[0].data.astype(np.double)
+                    theader = hdu[0].header
 
-    if wcs_orig is not None:
-        # We should do downscaling after conversion of the image back to linear flux scaling
-        log('Downscaling the image %dx' % upscale)
-        image = utils.rebin_image(image, upscale)
-        # The header from hips2fits describes the upscaled grid - restore the original WCS
-        header.update(wcs_orig.to_header(relax=True))
-        header['NAXIS1'] = image.shape[1]
-        header['NAXIS2'] = image.shape[0]
+                    # FIXME: hips2fits does not properly return the header for
+                    # SIP WCS, so we just copy the requested WCS over it
+                    if twcs.sip is not None:
+                        theader.update(twcs.to_header(relax=True))
+
+                    hdu.close()
+
+                    # Linearize asinh-scaled surveys (like Pan-STARRS) before
+                    # storing the tile, so that the reprojection below
+                    # interpolates in linear flux space
+                    tasinh = asinh
+                    if tasinh is None:
+                        # All PanSTARRS bands except g are stored in asinh scaling, as of May 2023
+                        tasinh = 'PanSTARRS' in hips and hips != 'PanSTARRS/DR1/g'
+                    if tasinh:
+                        x = timage * 0.4 * np.log(10)
+                        timage = np.exp(x) - np.exp(-x)
+
+                    # Write atomically so that an interrupted write does not
+                    # leave a truncated file in the cache
+                    fits.writeto(tilefile + '.tmp', timage, theader, overwrite=True)
+                    os.replace(tilefile + '.tmp', tilefile)
+
+        # Reproject the cached tile onto the exact requested grid
+        image = reproject_lanczos(
+            [tilefile], wcs=wcs, width=int(width), height=int(height), verbose=verbose
+        )
+
+        if image is None:
+            log('Cannot reproject cached HiPS tile onto the requested grid!')
+            if get_header:
+                return None, None
+            else:
+                return None
+
+        header = wcs.to_header(relax=True)
+        header['NAXIS1'] = int(width)
+        header['NAXIS2'] = int(height)
+
+    else:
+        for baseurl in [
+            'https://alasky.u-strasbg.fr/hips-image-services/hips2fits',
+            'https://alaskybis.u-strasbg.fr/hips-image-services/hips2fits',
+        ]:
+            url = baseurl + '?' + urlencode(params)
+
+            try:
+                t0 = time.time()
+                hdu = fits.open(url)
+                t1 = time.time()
+                log('Downloaded HiPS image in %.2f s' % (t1 - t0))
+                break
+            except Exception:
+                log('Failed downloading HiPS image from', url)
+                hdu = None
+
+        if hdu is None:
+            log('Cannot download HiPS image!')
+            if get_header:
+                return None, None
+            else:
+                return None
+
+        image = hdu[0].data.astype(np.double)
+        header = hdu[0].header
+
+        # FIXME: hips2fits does not properly return the header for SIP WCS, so we just copy the original WCS over it
+        if wcs is not None and wcs.sip is not None:
+            wheader = wcs.to_header(relax=True)
+            header.update(wheader)
+
+        hdu.close()
+
+        if asinh is None:
+            # All PanSTARRS bands except g are stored in asinh scaling, as of May 2023
+            if 'PanSTARRS' in hips and hips != 'PanSTARRS/DR1/g':
+                asinh = True
+
+        if asinh:
+            # Fix asinh flux scaling
+            # image = np.sinh(image*np.log(10)/2.5)
+            x = image * 0.4 * np.log(10)
+            image = np.exp(x) - np.exp(-x)
+
+        if wcs_orig is not None:
+            # We should do downscaling after conversion of the image back to linear flux scaling
+            log('Downscaling the image %dx' % upscale)
+            image = utils.rebin_image(image, upscale)
+            # The header from hips2fits describes the upscaled grid - restore the original WCS
+            header.update(wcs_orig.to_header(relax=True))
+            header['NAXIS1'] = image.shape[1]
+            header['NAXIS2'] = image.shape[0]
 
     if normalize:
         # Normalize the image to have median=100 and std=10, corresponding to GAIN=1 assuming Poissonian background
@@ -223,6 +332,57 @@ def get_hips_image(
         return image, header
     else:
         return image
+
+
+def _hips_canonical_tile(hips, wcs, width, height, _cachedir):
+    """Compute a canonical (grid-aligned, padded) tile request for caching.
+
+    The tile keeps the pixel transform (scale, rotation, flip) of the
+    requested WCS verbatim, but its center is snapped to a fixed sky grid
+    with half-field spacing, and its size is padded so that the tile still
+    fully covers the request after the center shift. Nearby tasks therefore
+    map onto the same cached tile.
+
+    Returns ``(filename, tile_wcs, tile_width, tile_height)``.
+    """
+    from astropy.wcs.utils import proj_plane_pixel_scales
+
+    # deg/pix
+    pixscale = float(np.mean(proj_plane_pixel_scales(wcs.celestial)))
+
+    cra, cdec = wcs.wcs.crval[:2]
+
+    # Snap the center to a grid with half-field spacing
+    step = 0.5 * max(width, height) * pixscale
+    qra = np.round(cra / step) * step % 360
+    qdec = np.clip(np.round(cdec / step) * step, -90, 90)
+
+    # Pad the tile so that it still covers the whole request after the
+    # center shift (at most step/2 along any axis), plus some slack
+    pad = int(np.ceil(0.25 * max(width, height))) + 32
+    twidth = int(np.ceil((width + 2 * pad) / 64)) * 64
+    theight = int(np.ceil((height + 2 * pad) / 64)) * 64
+
+    twcs = wcs.deepcopy()
+    twcs.wcs.crval = [qra, qdec]
+    twcs.wcs.crpix = [(twidth + 1) / 2, (theight + 1) / 2]
+    twcs.pixel_shape = (twidth, theight)
+
+    # Distinguish tiles by survey, padded size, grid-snapped center and the
+    # pixel transform (pixel scale, rotation, flip)
+    if hasattr(wcs.wcs, 'cd'):
+        transform = np.asarray(wcs.wcs.cd)
+    else:
+        transform = np.asarray(wcs.wcs.pc) * np.asarray(wcs.wcs.cdelt)[:, None]
+    thash = hashlib.md5(np.round(transform, 12).tobytes()).hexdigest()[:8]
+
+    safe_hips = hips.replace('CDS/P/', '').replace('/', '_')
+    filename = os.path.join(
+        _cachedir,
+        '%s_%dx%d_%.4f_%+.4f_%s.fits' % (safe_hips, twidth, theight, qra, qdec, thash),
+    )
+
+    return filename, twcs, twidth, theight
 
 
 def dilate_mask(mask, dilate=5):

--- a/stdpipe/utils.py
+++ b/stdpipe/utils.py
@@ -3,6 +3,9 @@ import re
 import requests
 import dateutil
 import shlex
+import fcntl
+
+from contextlib import contextmanager
 
 from tqdm.auto import tqdm
 
@@ -37,6 +40,33 @@ def get_data_path(dataname):
     Returns full path to the data file located in the module data/ folder
     """
     return os.path.join(os.path.dirname(__file__), 'data', dataname)
+
+
+@contextmanager
+def file_lock(path):
+    """Exclusive inter-process lock using a companion ``<path>.lock`` file.
+
+    Based on ``fcntl.flock`` (advisory locking) - all cooperating processes
+    must acquire the lock before touching the file. The lock is automatically
+    released if the process dies, so no stale locks are possible. Lock files
+    are left behind (they are empty and harmless) as removing them would
+    race with other processes opening them.
+
+    The typical pattern for cache downloads is::
+
+        if not os.path.exists(filename):
+            with file_lock(filename):
+                if not os.path.exists(filename):  # re-check inside the lock
+                    ... download and write filename ...
+    """
+    lockpath = path + '.lock'
+    os.makedirs(os.path.dirname(lockpath) or '.', exist_ok=True)
+    with open(lockpath, 'w') as lockfile:
+        fcntl.flock(lockfile, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lockfile, fcntl.LOCK_UN)
 
 
 def download(url, filename=None, overwrite=False, verbose=False):


### PR DESCRIPTION
Depends on #22 (uses `utils.file_lock` introduced there).

HiPS template requests previously hit the hips2fits service on every call with a task-specific exact WCS in the URL, so repeated processing of the same sky position re-downloaded the same data every time.

With `_cachedir` set, the request is canonicalized into a grid-aligned, padded tile: the center is snapped to a fixed sky grid with half-field spacing, the size is padded to keep full coverage after the shift, and the pixel transform (scale/rotation/flip) is kept verbatim. Repeated or slightly offset requests therefore share the same cached tile, which is then reprojected onto the exact requested grid with `reproject_lanczos`. Asinh-scaled surveys are linearized before the tile is stored, so reprojection interpolates in linear flux space.

Details:

- Downloads are guarded by `utils.file_lock`, written atomically, and use `cache=False` to avoid flooding astropy's URL cache.
- Default behaviour without `_cachedir` is unchanged; upscaled requests skip the cache.
- Tested end-to-end: first call downloads in ~4 s, a slightly offset second call hits the cached tile in ~0.1 s.
